### PR TITLE
Update old func names

### DIFF
--- a/examples/1_accounts.py
+++ b/examples/1_accounts.py
@@ -4,10 +4,10 @@ from web3 import Web3
 infura_url = "https://mainnet.infura.io/v3/YOUR_INFURA_API_KEY_GOES_HERE"
 web3 = Web3(Web3.HTTPProvider(infura_url))
 
-print(web3.isConnected())
+print(web3.is_connected())
 
-print(web3.eth.blockNumber)
+print(web3.eth.block_number)
 
 # Fill in your account here
-balance = web3.eth.getBalance("YOUR_ACCOUNT_GOES_HERE")
-print(web3.fromWei(balance, "ether"))
+balance = web3.eth.get_balance("YOUR_ACCOUNT_GOES_HERE")
+print(web3.from_wei(balance, "ether"))

--- a/examples/2_read_smart_contracts.py
+++ b/examples/2_read_smart_contracts.py
@@ -13,8 +13,8 @@ address = '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07'
 contract = web3.eth.contract(address=address, abi=abi)
 
 totalSupply = contract.functions.totalSupply().call()
-print(web3.fromWei(totalSupply, 'ether'))
+print(web3.from_wei(totalSupply, 'ether'))
 print(contract.functions.name().call())
 print(contract.functions.symbol().call())
 balance = contract.functions.balanceOf('0xd26114cd6EE289AccF82350c8d8487fedB8A0C07').call()
-print(web3.fromWei(balance, 'ether'))
+print(web3.from_wei(balance, 'ether'))

--- a/examples/3_send_transactions.py
+++ b/examples/3_send_transactions.py
@@ -7,18 +7,18 @@ account_1 = '' # Fill me in
 account_2 = '' # Fill me in
 private_key = '' # Fill me in
 
-nonce = web3.eth.getTransactionCount(account_1)
+nonce = web3.eth.get_transaction_count(account_1)
+
+print(nonce)
 
 tx = {
     'nonce': nonce,
     'to': account_2,
-    'value': web3.toWei(1, 'ether'),
+    'value': web3.to_wei(1, 'ether'),
     'gas': 2000000,
-    'gasPrice': web3.toWei('50', 'gwei'),
+    'gasPrice': web3.to_wei('50', 'gwei'),
 }
 
-signed_tx = web3.eth.account.signTransaction(tx, private_key)
-
-tx_hash = web3.eth.sendRawTransaction(signed_tx.rawTransaction)
-
-print(web3.toHex(tx_hash))
+signed_tx = web3.eth.account.sign_transaction(tx, private_key)
+tx_hash = web3.eth.send_raw_transaction(signed_tx.rawTransaction)
+print(web3.to_hex(tx_hash))

--- a/examples/4_write_smart_contracts.py
+++ b/examples/4_write_smart_contracts.py
@@ -12,7 +12,7 @@ web3.eth.defaultAccount = web3.eth.accounts[0]
 # Greeter contract ABI
 abi = json.loads('[{"constant":false,"inputs":[{"name":"_greeting","type":"string"}],"name":"setGreeting","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"greet","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"greeting","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"inputs":[],"payable":false,"stateMutability":"nonpayable","type":"constructor"}]')
 # Greeter contract address - convert to checksum address
-address = web3.toChecksumAddress('') # FILL ME IN
+address = web3.to_checksum_address('') # FILL ME IN
 # Initialize contract
 contract = web3.eth.contract(address=address, abi=abi)
 # Read the default greeting
@@ -20,7 +20,7 @@ print(contract.functions.greet().call())
 # Set a new greeting
 tx_hash = contract.functions.setGreeting('HEELLLLOOOOOO!!!').transact()
 # Wait for transaction to be mined
-web3.eth.waitForTransactionReceipt(tx_hash)
+web3.eth.wait_for_transaction_receipt(tx_hash)
 # Display the new greeting value
 print('Updated contract greeting: {}'.format(
     contract.functions.greet().call()

--- a/examples/5_deploy_smart_contracts.py
+++ b/examples/5_deploy_smart_contracts.py
@@ -18,7 +18,7 @@ Greeter = web3.eth.contract(abi=abi, bytecode=bytecode)
 tx_hash = Greeter.constructor().transact()
 
 # # Wait for the transaction to be mined, and get the transaction receipt
-tx_receipt = web3.eth.waitForTransactionReceipt(tx_hash)
+tx_receipt = web3.eth.wait_for_transaction_receipt(tx_hash)
 
 # # Create the contract instance with the newly-deployed address
 contract = web3.eth.contract(
@@ -37,7 +37,7 @@ print('Default contract greeting: {}'.format(
 tx_hash = contract.functions.setGreeting('HELLOOOO!!!!').transact()
 
 # # Wait for transaction to be mined...
-web3.eth.waitForTransactionReceipt(tx_hash)
+web3.eth.wait_for_transaction_receipt(tx_hash)
 
 # # Display the new greeting value
 print('Updated contract greeting: {}'.format(

--- a/examples/6_inspecting_blocks.py
+++ b/examples/6_inspecting_blocks.py
@@ -5,15 +5,15 @@ infura_url = "https://mainnet.infura.io/v3/YOUR_INFURA_API_KEY_GOES_HERE"
 web3 = Web3(Web3.HTTPProvider(infura_url))
 
 # get latest block number
-print(web3.eth.blockNumber)
+print(web3.eth.block_number)
 
 # get latest block
-print(web3.eth.getBlock('latest'))
+print(web3.eth.get_block('latest'))
 
 # get latest 10 blocks
-latest = web3.eth.blockNumber
+latest = web3.eth.block_number
 for i in range(0, 10):
-  print(web3.eth.getBlock(latest - i))
+  print(web3.eth.get_block(latest - i))
 
 # get transaction from specific block
 hash = '0x66b3fd79a49dafe44507763e9b6739aa0810de2c15590ac22b5e2f0a3f502073'


### PR DESCRIPTION
This commit replaces some old and erroneous function names with new and valid ones. For example, 'fromWei' is now being used as 'from_wei'. These changes are made to prevent error messages and keep the code up to date.